### PR TITLE
aria2: fix ca_certificate path

### DIFF
--- a/applications/app-meta-aria2/Makefile
+++ b/applications/app-meta-aria2/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 META_TITLE:=Aria2下载器
 META_TITLE.en:=Aria2
 META_DEPENDS:=+aria2 +ariang +luci-app-aria2 +luci-i18n-aria2-zh-cn +aria2-entry-deps

--- a/applications/app-meta-aria2/root/etc/uci-defaults/50_app-meta-aria2
+++ b/applications/app-meta-aria2/root/etc/uci-defaults/50_app-meta-aria2
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# fix ca_certificate
+uci -q get aria2.main.ca_certificate >/dev/null && exit 0
+
+uci -q batch <<-EOF >/dev/null
+	set aria2.main.ca_certificate=/etc/ssl/certs/ca-certificates.crt
+	commit aria2
+EOF
+
+exit 0


### PR DESCRIPTION
Luci may auto enable check_certificate, but leave ca_certificate blank, makes all https tasks failed.

Set a default ca_certificate path to workaround this.