### PR TITLE
update rtp2httpd to 3.12.1-r1

### DIFF
--- a/applications/app-meta-rtp2httpd/Makefile
+++ b/applications/app-meta-rtp2httpd/Makefile
@@ -2,7 +2,7 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_VERSION:=3.10.1
+PKG_VERSION:=3.12.1
 PKG_RELEASE:=1
 META_TITLE:=rtp2httpd
 META_DEPENDS:=+rtp2httpd +luci-app-rtp2httpd +luci-i18n-rtp2httpd-zh-cn


### PR DESCRIPTION
Update rtp2httpd metadata to version 3.12.1-r1

This PR updates the package version in the app metadata.

Automated PR from [stackia/rtp2httpd](https://github.com/stackia/rtp2httpd)