### PR TITLE
update rtp2httpd to 3.13.5-r1

### DIFF
--- a/applications/app-meta-rtp2httpd/Makefile
+++ b/applications/app-meta-rtp2httpd/Makefile
@@ -2,8 +2,8 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_VERSION:=3.12.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.13.5
+PKG_RELEASE:=1
 META_TITLE:=rtp2httpd
 META_DEPENDS:=+rtp2httpd +luci-app-rtp2httpd +luci-i18n-rtp2httpd-zh-cn
 META_DESCRIPTION:=面向 IPTV 场景的组播、RTSP、HTTP 流媒体转发服务，内置状态页面和 Web 播放器。可替代 udpxy 和 msd_lite。


### PR DESCRIPTION
Update rtp2httpd metadata to version 3.13.5-r1

This PR updates the package version in the app metadata.

Automated PR from [stackia/rtp2httpd](https://github.com/stackia/rtp2httpd)