### PR TITLE
app-meta-51ddns: update to 0.6.4

### DIFF
--- a/applications/app-meta-51ddns/Makefile
+++ b/applications/app-meta-51ddns/Makefile
@@ -2,7 +2,7 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_VERSION:=0.6.3
+PKG_VERSION:=0.6.4
 PKG_RELEASE:=1
 META_TITLE:=51DDNS 远程控制
 META_TITLE.en:=51DDNS Remote Access


### PR DESCRIPTION
## app-meta-51ddns: 0.6.3 → 0.6.4

仅将 `PKG_VERSION` 从 `0.6.3` 更新为 `0.6.4`，`PKG_RELEASE` 保持 `1`。

- 对应四份正式 Agent 0.6.4-r1（x86_64 / ARM64，APK / IPK），软件包 PR：[linkease/istore-repo#783](https://github.com/linkease/istore-repo/pull/783)。
- LuCI 保持 `0.1.4-r1`；标题、描述、依赖、支持架构、入口、作者和图标均不变。
- [正式源码与发布说明](https://github.com/21hkcloud/51ddns-openwrt/releases/tag/v0.6.4)。
- [正式包构建 CI](https://github.com/21hkcloud/51ddns-openwrt/actions/runs/34697421876)。

验证：差异仅一行版本号，`git diff --check` 通过；正式 Agent 包已逐份重新校验 SHA-256、架构、版本与依赖。

请在软件包 PR 合并并进入线上软件源后再合并本 PR，避免应用展示为 0.6.4 时仍只能安装 0.6.3。合并不等于已完成真实 iStore 搜索、安装和升级验收，这些仍需后续检查。
